### PR TITLE
free queue before returning from graph_bfs_loop

### DIFF
--- a/graph/src/graph_bfs.c
+++ b/graph/src/graph_bfs.c
@@ -69,7 +69,10 @@ static void	graph_bfs_loop(
 		v = arr_get(&queue, i);
 		v->valid = false;
 		if (graph_iter_edges(res, &queue, t, i))
+		{
+			arr_free(&queue);
 			return ;
+		}
 		i++;
 	}
 	arr_free(&queue);


### PR DESCRIPTION
Free queue in ``graph_bfs_loop`` if ``graph_iter_edges`` has a positive return value.