### PR TITLE
Core System Udpate

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -13,6 +13,8 @@
 # TAG += value [value, ...]
 # Values that contain spaces should be placed between quotes (\" \").
 
+JAVADOC_BLOCK = YES
+
 #---------------------------------------------------------------------------
 # Project related configuration options
 #---------------------------------------------------------------------------

--- a/array/inc/arr.h
+++ b/array/inc/arr.h
@@ -1,8 +1,8 @@
 /******************************************************************************
  *
- * \authors Julius Koskela
- *
  * \brief Dynamic array implementation library.
+ *
+ * \authors Julius Koskela
  *
  *****************************************************************************/
 
@@ -21,38 +21,38 @@ typedef struct s_array
 	size_t		elem_size;
 }				t_array;
 
-t_array			arr_new(size_t len, size_t elem_size);
-ssize_t			arr_free(t_array *src);
-ssize_t			arr_null(t_array *src);
-void			*arr_get(t_array *src, size_t index);
-void			*arr_get_first(t_array *src);
-void			*arr_get_last(t_array *src);
-void			*arr_take(void *dst, t_array *src, size_t index);
-void			*arr_take_first(void *dst, t_array *src);
-void			*arr_take_last(void *dst, t_array *src);
-ssize_t			arr_grow(t_array *src, size_t new_size);
-ssize_t			arr_assign(t_array *dst, void *data, size_t len);
-ssize_t			arr_add(t_array *src, void *node, size_t index);
-ssize_t			arr_add_first(t_array *src, void *node);
-ssize_t			arr_add_last(t_array *src, void *node);
-ssize_t			arr_add_mult(t_array *src, size_t count, ...);
-ssize_t			arr_put(t_array *dst, void *src, size_t size);
-ssize_t			arr_del(t_array *src, size_t index);
-ssize_t			arr_del_first(t_array *src);
-ssize_t			arr_del_last(t_array *src);
-ssize_t			arr_find(t_array *src, void *key);
-ssize_t			arr_search(t_array *src, t_array *key);
-ssize_t			arr_copy(t_array *dst, t_array *src);
-ssize_t			arr_join(t_array *dst, t_array *src);
-ssize_t			arr_join_mult(t_array *dst, size_t count, ...);
-ssize_t			arr_rotate(t_array *arr, ssize_t steps);
-ssize_t			arr_iter(t_array *src,
-					ssize_t (*f)(void *, size_t));
-ssize_t			arr_iter_range(t_array *src, size_t start, size_t end,
-					ssize_t (*f)(void *, size_t));
-ssize_t			arr_find_by(t_array *arr, const void *key,
-					ssize_t (*f)(const void *, const void *));
-ssize_t			arr_parse(t_array *dst, t_array *src,
-					ssize_t (*f)(t_array *, void *));
+t_array		arr_new(size_t len, size_t elem_size);
+ssize_t		arr_free(t_array *src);
+ssize_t		arr_null(t_array *src);
+void		*arr_get(t_array *src, size_t index);
+void		*arr_get_first(t_array *src);
+void		*arr_get_last(t_array *src);
+void		*arr_take(void *dst, t_array *src, size_t index);
+void		*arr_take_first(void *dst, t_array *src);
+void		*arr_take_last(void *dst, t_array *src);
+ssize_t		arr_grow(t_array *src, size_t new_size);
+ssize_t		arr_assign(t_array *dst, void *data, size_t len);
+ssize_t		arr_add(t_array *src, void *node, size_t index);
+ssize_t		arr_add_first(t_array *src, void *node);
+ssize_t		arr_add_last(t_array *src, void *node);
+ssize_t		arr_add_mult(t_array *src, size_t count, ...);
+ssize_t		arr_put(t_array *dst, void *src, size_t size);
+ssize_t		arr_del(t_array *src, size_t index);
+ssize_t		arr_del_first(t_array *src);
+ssize_t		arr_del_last(t_array *src);
+ssize_t		arr_find(t_array *src, void *key);
+ssize_t		arr_search(t_array *src, t_array *key);
+ssize_t		arr_copy(t_array *dst, t_array *src);
+ssize_t		arr_join(t_array *dst, t_array *src);
+ssize_t		arr_join_mult(t_array *dst, size_t count, ...);
+ssize_t		arr_rotate(t_array *arr, ssize_t steps);
+ssize_t		arr_iter(t_array *src,
+			ssize_t (*f)(void *, size_t));
+ssize_t		arr_iter_range(t_array *src, size_t start, size_t end,
+			ssize_t (*f)(void *, size_t));
+ssize_t		arr_find_by(t_array *arr, const void *key,
+			ssize_t (*f)(const void *, const void *));
+ssize_t		arr_parse(t_array *dst, t_array *src,
+			ssize_t (*f)(t_array *, void *));
 
 #endif

--- a/inc/config.h
+++ b/inc/config.h
@@ -1,0 +1,18 @@
+#ifndef CONFIG_H
+# define CONFIG_H
+
+# define CR_ACTIVE 1
+# define CR_STACK_TRACE_MAX 1024
+# define CR_TRACK_ALLOC 1
+# define CR_TRACK_ALLOC_BACKTRACE 1
+# define CR_TRACK_ERROR 1
+# define CR_TRACK_ERROR_BACKTRACE 1
+# define CR_RECOVERY_POLICY 0
+
+# define CR_MAP_START_CAPACITY 128
+# define CR_MAP_LOAD_FACTOR 1
+# define CR_MAP_HASH map_hash_1
+# define CR_MAP_PROBE map_probe_linear
+# define CR_MAP_RESIZE map_resize_linear
+
+#endif

--- a/inc/const.h
+++ b/inc/const.h
@@ -1,0 +1,26 @@
+#ifndef CONST_H
+# define CONST_H
+
+# define CR_PI 3.14159265358979323846
+# define CR_MEM_NULL (t_mem) {0, NULL}
+# define CR_STOP -1
+# define CR_CONTINUE 1
+# define CR_SUCCESS 1
+# define CR_FAIL 0
+# define CR_TRUE 1
+# define CR_FALSE 0
+# define CR_NOALLOC 0
+# define CR_EMPTY -1
+# define CR_WRITE 0
+# define CR_APPEND 1
+# define CR_PREPEND -1
+# define CR_STRING NULL
+# define CR_PARR_NULL (t_parray) {NULL, 0, 0}
+# define CR_ARR_NULL (t_array) {NULL, 0, 0, 0}
+# define CR_GRAPH_NULL (t_graph) {CR_MAP_NULL, 0, NULL}
+# define CR_GRAPH_NULL_NODE (t_graph_node) {NULL, CR_ARR_NULL, CR_ARR_NULL, 0, NULL, NULL}
+# define CR_GRAPH_EDGE_NULL (t_graph_edge) {NULL, NULL, 0, NULL}
+# define CR_MAP_NULL_NODE (t_map_node) {NULL, NULL}
+# define CR_MAP_NULL (t_map) {NULL, 0, 0, 0.0, NULL, NULL, NULL}
+
+#endif

--- a/inc/core.h
+++ b/inc/core.h
@@ -1,32 +1,6 @@
-#ifndef LIBCORE_H
-# define LIBCORE_H
+#ifndef CORE_H
+# define CORE_H
 
-# define CR_PI 3.14159265358979323846
-# define CR_STOP -1
-# define CR_CONTINUE 1
-# define CR_SUCCESS 1
-# define CR_FAIL 0
-# define CR_TRUE 1
-# define CR_FALSE 0
-# define CR_NOALLOC 0
-# define CR_EMPTY -1
-# define CR_WRITE 0
-# define CR_APPEND 1
-# define CR_PREPEND -1
-# define CR_STRING NULL
-# define CR_PARR_NULL (t_parray) {NULL, 0, 0}
-# define CR_ARR_NULL (t_array) {NULL, 0, 0, 0}
-# define CR_GRAPH_NULL (t_graph) {CR_MAP_NULL, 0, NULL}
-# define CR_GRAPH_NULL_NODE (t_graph_node) {NULL, CR_ARR_NULL, CR_ARR_NULL, 0, NULL, NULL}
-# define CR_GRAPH_EDGE_NULL (t_graph_edge) {NULL, NULL, 0, NULL}
-# define CR_MAP_NULL_NODE (t_map_node) {NULL, NULL}
-# define CR_MAP_NULL (t_map) {NULL, 0, 0, 0.0, NULL, NULL, NULL}
-# define CR_MAP_START_CAPACITY 128
-# define CR_MAP_LOAD_FACTOR 1
-# define CR_MAP_HASH map_hash_1
-# define CR_MAP_PROBE map_probe_linear
-# define CR_MAP_RESIZE map_resize_linear
-# define CR_PI 3.14159265358979323846
 # include <stdlib.h>
 # include <stdint.h>
 # include <string.h>
@@ -53,5 +27,7 @@
 # include "../string/inc/string.h"
 # include "../checks/inc/checks.h"
 # include "../system/inc/system.h"
+# include "const.h"
+# include "config.h"
 
 #endif

--- a/memory/src/mem_cpy.c
+++ b/memory/src/mem_cpy.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   mem_cpy.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: skoskine <skoskine@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: jkoskela <jkoskela@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/10/16 01:31:35 by jkoskela          #+#    #+#             */
-/*   Updated: 2021/05/11 09:41:23 by skoskine         ###   ########.fr       */
+/*   Updated: 2021/05/16 06:44:24 by jkoskela         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,10 +70,7 @@ void	*mem_cpy(void *restrict dst, const void *restrict src, size_t n)
 	src8 = (const uint8_t *)src;
 	qwords = n >> 3;
 	if (n > 8)
-	{
 		copy512((uint64_t *)dst, (const uint64_t *)src, qwords);
-		return (dst);
-	}
 	aligned_size = qwords << 3;
 	n -= aligned_size;
 	dst8 += aligned_size;

--- a/static.c
+++ b/static.c
@@ -1,0 +1,41 @@
+#include "inc/core.h"
+
+enum	e_system
+{
+	ACTIVATE,
+	RECOVERY_POLICY,
+	ERROR_TRACE,
+	ALLOC_TRACE,
+};
+
+t_core	*core_static()
+{
+	static t_core	core;
+
+	return (&core);
+}
+
+void	core_set(size_t flag)
+{
+	t_core	*core;
+
+	core = core_static();
+	if (flag == ACTIVATE)
+		core->active = true;
+}
+
+bool	core_check(size_t flag)
+{
+	t_core	*core;
+
+	core = core_static();
+	if (core->active = true)
+		return (core->active);
+}
+
+int	main(void)
+{
+	core_set(ACTIVATE);
+	if (core_check(ACTIVATE))
+		print("TRUE\n");
+}

--- a/string.c
+++ b/string.c
@@ -1,0 +1,67 @@
+#include "inc/core.h"
+
+typedef t_mem t_fstr;
+typedef t_parray t_page;
+
+t_fstr	fstr_new(size_t size)
+{
+	t_fstr	new;
+
+	new = core_malloc(size);
+	return (new);
+}
+
+t_fstr	fstr(const char *src)
+{
+	t_fstr	new;
+	size_t	len;
+
+	len = s_len (src);
+	new = fstr_new(len + 1);
+	mem_cpy(new.data, src, len + 1); 
+	return (new);
+}
+
+size_t	fstr_len(t_fstr src)
+{
+	return (src.size - 1);
+}
+
+t_mem	fstr_join(t_mem dst, t_mem src)
+{
+	t_mem	new;
+	uint8_t	*mem_dst;
+
+	new = core_malloc(dst.size + src.size);
+	mem_dst = new.data;
+	mem_cpy(mem_dst, dst.data, dst.size - 1);
+	mem_dst += dst.size - 1;
+	mem_cpy(mem_dst, src.data, src.size);	
+	return (new);
+}
+
+void	test_fstr_usage(void)
+{
+	t_fstr	s1;
+	t_fstr	s2;
+	t_fstr	s3;
+
+	s1 = fstr("New string!");
+	s2 = fstr("Another string...");
+	print("%s\n", s1.data);
+	print("%s\n", s2.data);
+	print("%llu\n", fstr_len(s1));
+
+	s3 = fstr_join(s1, s2);
+	core_free(&s1);
+	core_free(&s2);
+	core_free(&s3);
+}
+
+int main(void)
+{
+	core_activate();
+	test_fstr_usage();
+	core_log();
+	core_deactivate();
+}

--- a/system/Makefile
+++ b/system/Makefile
@@ -13,6 +13,7 @@ DEPFLAGS	=	-MT $@ -MMD -MP -MF $(DEP_DIR)$*.d
 COMPILE.c	=	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -c
 
 SRC_BASE	=	core_activate.c \
+				core_static.c \
 				core_deactivate.c \
 				core_debug.c \
 				core_error.c \

--- a/system/Makefile
+++ b/system/Makefile
@@ -16,9 +16,10 @@ SRC_BASE	=	core_activate.c \
 				core_deactivate.c \
 				core_debug.c \
 				core_error.c \
-				core_free.c \
 				core_log.c \
 				core_malloc.c \
+				core_realloc.c \
+				core_free.c \
 				core_stacktrace.c \
 
 SRC			=	$(addprefix $(SRC_DIR), $(SRC_BASE))

--- a/system/inc/system.h
+++ b/system/inc/system.h
@@ -6,7 +6,7 @@
 
 typedef t_parray t_page;
 
-typedef struct	s_error_pos
+typedef struct	s_file_pos
 {
 	const char	*func;
 	char		*file;
@@ -18,31 +18,6 @@ typedef struct	s_mem
 	size_t		size;
 	void		*data;
 }				t_mem;
-
-typedef struct	s_core
-{
-	uint8_t		active : 1;
-	uint8_t		track_errors : 1;
-	uint8_t		track_errors_backtrace : 1;
-	uint8_t		track_allocs : 1;
-	uint8_t		track_allocs_backtrace : 1;
-	t_parray	errors;
-	t_parray	allocs;
-}				t_core;
-
-typedef struct	s_tracker
-{
-	t_mem		mem;
-	t_page		trace;
-}				t_tracker;
-
-typedef struct	s_error
-{
-	char		*message;
-	t_page		trace;
-}				t_error;
-
-t_core	g_core;
 
 void	core_error(t_file_pos *err_pos, char *message);
 void	core_debug(t_file_pos *file_pos, size_t count, ...);

--- a/system/inc/system.h
+++ b/system/inc/system.h
@@ -2,16 +2,9 @@
 # define SYSTEM_H
 #include "../../inc/core.h"
 #include <execinfo.h>
-# define CR_RECOVERY_POLICY 0
 # define CR_FILE_POS &(t_file_pos){__FUNCTION__, __FILE__, __LINE__}
-# define CR_MEM_NULL (t_mem) {0, NULL}
-# define DEBUG core_debug
-# define ERROR core_error
-# define CR_ACTIVE 1
-# define CR_TRACK_ALLOC 1
-# define CR_TRACK_ALLOC_BACKTRACE 1
-# define CR_TRACK_ERROR 1
-# define CR_TRACK_ERROR_BACKTRACE 1
+
+typedef t_parray t_page;
 
 typedef struct	s_error_pos
 {
@@ -26,12 +19,6 @@ typedef struct	s_mem
 	void		*data;
 }				t_mem;
 
-typedef struct	s_system_flags
-{
-	uint8_t		track_errors : 1;
-	uint8_t		track_allocs : 1;
-}				t_system_flags;
-
 typedef struct	s_core
 {
 	uint8_t		active : 1;
@@ -41,19 +28,18 @@ typedef struct	s_core
 	uint8_t		track_allocs_backtrace : 1;
 	t_parray	errors;
 	t_parray	allocs;
-	size_t		alloc_index;
 }				t_core;
 
 typedef struct	s_tracker
 {
 	t_mem		mem;
-	char		*trace;
+	t_page		trace;
 }				t_tracker;
 
 typedef struct	s_error
 {
 	char		*message;
-	char		*trace;
+	t_page		trace;
 }				t_error;
 
 t_core	g_core;
@@ -64,8 +50,8 @@ void	core_activate();
 void	core_deactivate();
 void	core_log();
 t_mem	core_malloc(size_t bytes);
-t_mem	core_realloc(size_t bytes);
+ssize_t	core_realloc(t_mem *mem, size_t new_size);
 void	core_free(t_mem *mem);
-char	*core_stacktrace(size_t offset);
+t_page	core_stacktrace(size_t offset);
 
 #endif

--- a/system/inc/system_internal.h
+++ b/system/inc/system_internal.h
@@ -1,0 +1,30 @@
+#ifndef SYSTEM_INTERNAL_H
+# define SYSTEM_INTERNAL_H
+#include "../../inc/core.h"
+
+typedef struct	s_core
+{
+	uint8_t		active : 1;
+	uint8_t		track_errors : 1;
+	uint8_t		track_errors_backtrace : 1;
+	uint8_t		track_allocs : 1;
+	uint8_t		track_allocs_backtrace : 1;
+	t_parray	errors;
+	t_parray	allocs;
+}				t_core;
+
+typedef struct	s_tracker
+{
+	t_mem		mem;
+	t_page		trace;
+}				t_tracker;
+
+typedef struct	s_error
+{
+	char		*message;
+	t_page		trace;
+}				t_error;
+
+t_core	*core_static();
+
+#endif

--- a/system/src/core_activate.c
+++ b/system/src/core_activate.c
@@ -8,7 +8,6 @@ void	core_activate()
 	g_core.track_errors_backtrace = CR_TRACK_ERROR_BACKTRACE;
 	g_core.track_allocs = CR_TRACK_ALLOC;
 	g_core.track_allocs_backtrace = CR_TRACK_ALLOC_BACKTRACE;
-	g_core.alloc_index = 0;
 	if (g_core.track_errors == true)
 		g_core.errors = parr_new(1);
 	if (g_core.track_allocs == true)

--- a/system/src/core_activate.c
+++ b/system/src/core_activate.c
@@ -1,17 +1,21 @@
 #include "../../inc/core.h"
 #include "../inc/system.h"
+#include "../inc/system_internal.h"
 
 void	core_activate()
 {
-	g_core.active = true;
-	g_core.track_errors = CR_TRACK_ERROR;
-	g_core.track_errors_backtrace = CR_TRACK_ERROR_BACKTRACE;
-	g_core.track_allocs = CR_TRACK_ALLOC;
-	g_core.track_allocs_backtrace = CR_TRACK_ALLOC_BACKTRACE;
-	if (g_core.track_errors == true)
-		g_core.errors = parr_new(1);
-	if (g_core.track_allocs == true)
-		g_core.allocs = parr_new(1);
+	t_core	*core;
+
+	core = core_static();
+	core->active = true;
+	core->track_errors = CR_TRACK_ERROR;
+	core->track_errors_backtrace = CR_TRACK_ERROR_BACKTRACE;
+	core->track_allocs = CR_TRACK_ALLOC;
+	core->track_allocs_backtrace = CR_TRACK_ALLOC_BACKTRACE;
+	if (core->track_errors == true)
+		core->errors = parr_new(1);
+	if (core->track_allocs == true)
+		core->allocs = parr_new(1);
 	printf("\n\033[32;1mCORE SYSTEM\033[0m\n\n");
 	print("You have activated the core system for memory management and debugging.\n\n");
 }

--- a/system/src/core_deactivate.c
+++ b/system/src/core_deactivate.c
@@ -10,7 +10,8 @@ void	cr_free_trackers()
 	while (i < g_core.allocs.len)
 	{
 		t = parr_get(&g_core.allocs, i);
-		free(t->trace);
+		parr_free(&t->trace);
+		free(t);
 		i++;
 	}
 }
@@ -24,8 +25,9 @@ void	cr_free_errors()
 	while (i < g_core.errors.len)
 	{
 		t = parr_get(&g_core.errors, i);
-		free(t->trace);
+		parr_free(&t->trace);
 		free(t->message);
+		free(t);
 		i++;
 	}
 }

--- a/system/src/core_deactivate.c
+++ b/system/src/core_deactivate.c
@@ -1,15 +1,18 @@
 #include "../../inc/core.h"
 #include "../inc/system.h"
+#include "../inc/system_internal.h"
 
 void	cr_free_trackers()
 {
 	size_t	i;
 	t_tracker	*t;
+	t_core	*core;
+	core = core_static();
 
 	i = 0;
-	while (i < g_core.allocs.len)
+	while (i < core->allocs.len)
 	{
-		t = parr_get(&g_core.allocs, i);
+		t = parr_get(&core->allocs, i);
 		parr_free(&t->trace);
 		free(t);
 		i++;
@@ -20,11 +23,13 @@ void	cr_free_errors()
 {
 	size_t	i;
 	t_error	*t;
+	t_core	*core;
 
+	core = core_static();
 	i = 0;
-	while (i < g_core.errors.len)
+	while (i < core->errors.len)
 	{
-		t = parr_get(&g_core.errors, i);
+		t = parr_get(&core->errors, i);
 		parr_free(&t->trace);
 		free(t->message);
 		free(t);
@@ -34,14 +39,17 @@ void	cr_free_errors()
 
 void	core_deactivate()
 {
-	if (g_core.track_errors == true)
+	t_core	*core;
+
+	core = core_static();
+	if (core->track_errors == true)
 	{
 		cr_free_errors();
-		parr_free(&g_core.errors);
+		parr_free(&core->errors);
 	}
-	if (g_core.track_allocs == true)
+	if (core->track_allocs == true)
 	{
 		cr_free_trackers();
-		parr_free(&g_core.allocs);
+		parr_free(&core->allocs);
 	}
 }

--- a/system/src/core_debug.c
+++ b/system/src/core_debug.c
@@ -9,14 +9,15 @@ void	core_debug(t_file_pos *file_pos, size_t count, ...)
 	size_t	i;
 
 	header = format(
-			"\033[1;31m%s\033[0m, \033[1;31m%s\033[0m, \033[1;31m%d\033[0m",
-			file_pos->file,
-			file_pos->func,
-			file_pos->line);
+	"\033[1;31m%s\033[0m, \033[1;31m%s\033[0m, \033[1;31m%d\033[0m",
+	file_pos->file,
+	file_pos->func,
+	file_pos->line);
 	print("DEBUG ");
 	printf("%s\n", header);
 	free(header);
 	va_start(ap, count);
+	ret = NULL;
 	i = 0;
 	while (i < count)
 	{
@@ -25,6 +26,7 @@ void	core_debug(t_file_pos *file_pos, size_t count, ...)
 		free(ret);
 		i++;
 	}
+	// free(ret);
 	va_end(ap);
 	print("\n");
 }

--- a/system/src/core_debug.c
+++ b/system/src/core_debug.c
@@ -1,5 +1,6 @@
 #include "../../inc/core.h"
 #include "../inc/system.h"
+#include "../inc/system_internal.h"
 
 void	core_debug(t_file_pos *file_pos, size_t count, ...)
 {
@@ -26,7 +27,6 @@ void	core_debug(t_file_pos *file_pos, size_t count, ...)
 		free(ret);
 		i++;
 	}
-	// free(ret);
 	va_end(ap);
 	print("\n");
 }

--- a/system/src/core_error.c
+++ b/system/src/core_error.c
@@ -7,11 +7,11 @@ void	core_error(t_file_pos *err_pos, char *message)
 
 	error = malloc(sizeof(t_error));
 	error->message = format(
-			"ERROR \033[1;31m%s\033[0m, \033[1;31m%s\033[0m, \033[1;31m%d\033[0m\n%s",
-			err_pos->file,
-			err_pos->func,
-			err_pos->line,
-			message);
+	"ERROR \033[1;31m%s\033[0m, \033[1;31m%s\033[0m, \033[1;31m%d\033[0m\n%s",
+	err_pos->file,
+	err_pos->func,
+	err_pos->line,
+	message);
 	error->trace = core_stacktrace(1);
 	parr_add_last(&g_core.errors, error);
 }

--- a/system/src/core_error.c
+++ b/system/src/core_error.c
@@ -1,10 +1,13 @@
 #include "../../inc/core.h"
 #include "../inc/system.h"
+#include "../inc/system_internal.h"
 
 void	core_error(t_file_pos *err_pos, char *message)
 {
 	t_error	*error;
+	t_core	*core;
 
+	core = core_static();
 	error = malloc(sizeof(t_error));
 	error->message = format(
 	"ERROR \033[1;31m%s\033[0m, \033[1;31m%s\033[0m, \033[1;31m%d\033[0m\n%s",
@@ -12,6 +15,6 @@ void	core_error(t_file_pos *err_pos, char *message)
 	err_pos->func,
 	err_pos->line,
 	message);
-	error->trace = core_stacktrace(1);
-	parr_add_last(&g_core.errors, error);
+	error->trace = core_stacktrace(0);
+	parr_add_last(&core->errors, error);
 }

--- a/system/src/core_free.c
+++ b/system/src/core_free.c
@@ -1,18 +1,21 @@
 #include "../../inc/core.h"
 #include "../inc/system.h"
+#include "../inc/system_internal.h"
 
 static ssize_t	deactivate_tracker(t_mem *mem)
 {
 	t_tracker	*tracker;
 	size_t		i;
+	t_core	*core;
 
+	core = core_static();
 	i = 0;
-	while (i < g_core.allocs.len)
+	while (i < core->allocs.len)
 	{
-		tracker = parr_get(&g_core.allocs, i);
+		tracker = parr_get(&core->allocs, i);
 		if (tracker->mem.data == mem->data)
 		{
-			parr_del(&g_core.allocs, i);
+			parr_del(&core->allocs, i);
 			parr_free(&tracker->trace);
 			free(tracker);
 			return (true);
@@ -24,7 +27,10 @@ static ssize_t	deactivate_tracker(t_mem *mem)
 
 void	core_free(t_mem *mem)
 {
-	if (g_core.active && g_core.track_allocs)
+	t_core	*core;
+
+	core = core_static();
+	if (core->active && core->track_allocs)
 		deactivate_tracker(mem);
 	free(mem->data);
 	mem->data = NULL;

--- a/system/src/core_free.c
+++ b/system/src/core_free.c
@@ -13,6 +13,7 @@ static ssize_t	deactivate_tracker(t_mem *mem)
 		if (tracker->mem.data == mem->data)
 		{
 			parr_del(&g_core.allocs, i);
+			parr_free(&tracker->trace);
 			free(tracker);
 			return (true);
 		}

--- a/system/src/core_log.c
+++ b/system/src/core_log.c
@@ -1,6 +1,15 @@
 #include "../../inc/core.h"
 #include "../inc/system.h"
 
+ssize_t	print_line(void *data, size_t i)
+{
+	char	*str;
+
+	str = data;
+	print("%s\n", str);
+	return (i);
+}
+
 ssize_t	print_tracker(void *data, size_t i)
 {
 	t_tracker *tracker;
@@ -11,8 +20,8 @@ ssize_t	print_tracker(void *data, size_t i)
 		printf("memptr: \033[1;31m%p\033[0m\n", tracker->mem.data);
 		printf("memsize: \033[1;31m%lu\033[0m\n", tracker->mem.size);
 	}
-	if (tracker->trace)
-		printf("%s\n", tracker->trace);
+	if (!(parr_null(&tracker->trace)))
+		parr_iter(&tracker->trace, print_line);
 	return (i);
 }
 
@@ -23,8 +32,8 @@ ssize_t	print_error(void *data, size_t i)
 	error = data;
 	if (error->message)
 		printf("%s\n", error->message);
-	if (error->trace)
-		printf("%s\n", error->trace);
+	if (!(parr_null(&error->trace)))
+		parr_iter(&error->trace, print_line);
 	return (i);
 }
 

--- a/system/src/core_log.c
+++ b/system/src/core_log.c
@@ -1,5 +1,6 @@
 #include "../../inc/core.h"
 #include "../inc/system.h"
+#include "../inc/system_internal.h"
 
 ssize_t	print_line(void *data, size_t i)
 {
@@ -22,6 +23,7 @@ ssize_t	print_tracker(void *data, size_t i)
 	}
 	if (!(parr_null(&tracker->trace)))
 		parr_iter(&tracker->trace, print_line);
+	print("\n");
 	return (i);
 }
 
@@ -34,13 +36,17 @@ ssize_t	print_error(void *data, size_t i)
 		printf("%s\n", error->message);
 	if (!(parr_null(&error->trace)))
 		parr_iter(&error->trace, print_line);
+	print("\n");
 	return (i);
 }
 
 void	core_log()
 {
-	if (g_core.track_errors == true)
-		parr_iter(&g_core.errors, print_error);
-	if (g_core.track_allocs == true)
-		parr_iter(&g_core.allocs, print_tracker);
+	t_core	*core;
+
+	core = core_static();
+	if (core->track_errors == true)
+		parr_iter(&core->errors, print_error);
+	if (core->track_allocs == true)
+		parr_iter(&core->allocs, print_tracker);
 }

--- a/system/src/core_malloc.c
+++ b/system/src/core_malloc.c
@@ -6,9 +6,9 @@ void	create_tracker(t_mem mem)
 
 	tracker = malloc(sizeof(t_tracker));
 	if (g_core.track_allocs_backtrace == true)
-		tracker->trace = core_stacktrace(1);
+		tracker->trace = core_stacktrace(3);
 	else
-		tracker->trace = NULL;
+		tracker->trace = CR_PARR_NULL;
 	tracker->mem = mem;
 	parr_add_last(&g_core.allocs, tracker);
 }
@@ -37,7 +37,6 @@ t_mem	core_malloc(size_t bytes)
 
 	out.data = malloc(bytes);
 	out.size = bytes;
-	g_core.alloc_index++;
 	if (g_core.active == true)
 		if (!(core_malloc_setup(out)))
 			return (CR_MEM_NULL);

--- a/system/src/core_malloc.c
+++ b/system/src/core_malloc.c
@@ -1,20 +1,26 @@
 #include "../inc/system.h"
+#include "../inc/system_internal.h"
 
 void	create_tracker(t_mem mem)
 {
 	t_tracker	*tracker;
+	t_core		*core;
 
+	core = core_static();
 	tracker = malloc(sizeof(t_tracker));
-	if (g_core.track_allocs_backtrace == true)
-		tracker->trace = core_stacktrace(3);
+	if (core->track_allocs_backtrace == true)
+		tracker->trace = core_stacktrace(2);
 	else
 		tracker->trace = CR_PARR_NULL;
 	tracker->mem = mem;
-	parr_add_last(&g_core.allocs, tracker);
+	parr_add_last(&core->allocs, tracker);
 }
 
 ssize_t	core_malloc_setup(t_mem mem)
 {
+	t_core	*core;
+
+	core = core_static();
 	if (!mem.data && CR_RECOVERY_POLICY == 0)
 	{
 		core_error(CR_FILE_POS, "FAILED ALLOCATION");
@@ -26,7 +32,7 @@ ssize_t	core_malloc_setup(t_mem mem)
 		core_error(CR_FILE_POS, "FAILED ALLOCATION");
 		return (0);
 	}
-	if (g_core.track_allocs == 1)
+	if (core->track_allocs == 1)
 		create_tracker(mem);
 	return (1);
 }
@@ -34,10 +40,12 @@ ssize_t	core_malloc_setup(t_mem mem)
 t_mem	core_malloc(size_t bytes)
 {
 	t_mem	out;
+	t_core	*core;
 
+	core = core_static();
 	out.data = malloc(bytes);
 	out.size = bytes;
-	if (g_core.active == true)
+	if (core->active == true)
 		if (!(core_malloc_setup(out)))
 			return (CR_MEM_NULL);
 	return (out);

--- a/system/src/core_realloc.c
+++ b/system/src/core_realloc.c
@@ -1,4 +1,5 @@
 #include "../../inc/core.h"
+#include "../inc/system_internal.h"
 
 ssize_t	core_realloc(t_mem *mem, size_t new_size)
 {

--- a/system/src/core_realloc.c
+++ b/system/src/core_realloc.c
@@ -1,6 +1,6 @@
 #include "../../inc/core.h"
 
-t_mem	core_realloc(t_mem *mem, size_t new_size)
+ssize_t	core_realloc(t_mem *mem, size_t new_size)
 {
 	t_mem	new;
 
@@ -9,6 +9,7 @@ t_mem	core_realloc(t_mem *mem, size_t new_size)
 		mem_cpy(new.data, mem->data, new_size);
 	else
 		mem_cpy(new.data, mem->data, mem->size);
-	free(mem->data);
+	core_free(mem);
 	*mem = new;
+	return (new.size);
 }

--- a/system/src/core_stacktrace.c
+++ b/system/src/core_stacktrace.c
@@ -1,25 +1,21 @@
 #include "../inc/system.h"
-# define CR_STACK_TRACE_MAX 1024
 
-char	*core_stacktrace(size_t offset)
+t_page	core_stacktrace(size_t offset)
 {
-	char		*trace;
+	t_page		trace;
 	char		**strings;
 	size_t		size;
 	void		*array[CR_STACK_TRACE_MAX];
 	size_t		i;
 
-	trace = NULL;
+	trace = parr_new(1);;
 	offset++;
 	size = backtrace(array, CR_STACK_TRACE_MAX);
 	strings = backtrace_symbols(array, size);
-	trace = s_join(trace, strings[offset]);
-	trace = s_join_free(trace, "\n", 1);
 	i = offset + 1;
 	while (i < size)
 	{
-		trace = s_join_free(trace, strings[i], 1);
-		trace = s_join_free(trace, "\n", 1);
+		parr_add_last(&trace, strings[i]);
 		i++;
 	}
 	free(strings);

--- a/system/src/core_stacktrace.c
+++ b/system/src/core_stacktrace.c
@@ -1,4 +1,5 @@
 #include "../inc/system.h"
+#include "../inc/system_internal.h"
 
 t_page	core_stacktrace(size_t offset)
 {

--- a/system/src/core_static.c
+++ b/system/src/core_static.c
@@ -1,0 +1,10 @@
+#include "../../inc/core.h"
+#include "../inc/system_internal.h"
+#include "../inc/system.h"
+
+t_core	*core_static()
+{
+	static t_core	core;
+
+	return (&core);
+}

--- a/tests/test_system_usage.c
+++ b/tests/test_system_usage.c
@@ -1,4 +1,6 @@
 #include "../inc/core.h"
+# define DEBUG core_debug
+# define ERROR core_error
 
 void	test_debug()
 {


### PR DESCRIPTION
Created a System context that provides tools for debugging and tracking allocations etc.

# Features

- Provides core_malloc which creates a new memory area and also stores it's size in the struct. core_malloc also has debugging abilities in conjunction with the core system. You can activate allocation tracking in which case all allocations made with core_malloc will be registered in the core struct. Core_malloc can be configured to use different recovery policies. For example if recovery policy 0 (abort) is used, then failed allocations will exit the program. 1 Means user will define how recovery is handled an a null t_mem struct is returned with size 0.
- Provides core_realloc, which reallocates memory to a new memory area. Tracking is updated accordingly.
- Provides core_free which frees the memory aread and updates tracking accordingly.
- Provides core_error which takes in a macro CR_FILE_POS to provide file position info for the error as well as an error message.
- Provides core_debug which takes in a macro CR_FILE_POS to provide file position information with the debug message. Also is a variable length array so multiple formatted debug messages can be passed at once.
- Provides core_activate which activates the alloc tracking and error functionality. Configured using header macros:

```
# define CR_ACTIVE 1
# define CR_STACK_TRACE_MAX 1024
# define CR_TRACK_ALLOC 1
# define CR_TRACK_ALLOC_BACKTRACE 1
# define CR_TRACK_ERROR 1
# define CR_TRACK_ERROR_BACKTRACE 1
# define CR_RECOVERY_POLICY 0
```

If user doesn't activate the core, the functions will work, but note use the extended functionality.

# Usage example

Here's an example output from a test program using the features:

```c
❯ ./a.out

CORE SYSTEM

You have activated the core system for memory management and debugging.


CORE SYSTEM EXAMPLE

Usage examples for core system.


MEMORY MANAGEMENT

We can track memory allocationsand get size and allocation backtrace.

memptr: 0x55c54537f760
memsize: 8
./a.out(test_malloc+0x25) [0x55c54521e4ec]
./a.out(main+0x56) [0x55c54521e577]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fa18ef040b3]
./a.out(_start+0x2e) [0x55c54521e1ce]


DEBUGGING

We can create debug messages which contain file, func, line info.

DEBUG tests/test_system_usage.c, test_debug, 16
Position: 3
Character: d
Pointer: 0x55c54537f2a3

DEBUG tests/test_system_usage.c, test_debug, 16
Position: 0
Character: a
Pointer: 0x55c54537f2a0


ERROR HANDLING

We can create error messages and print them with core_log().

ERROR tests/test_system_usage.c, test_error, 28
A terrible error has occured!

./a.out(test_error+0xdf) [0x55c54521e4b0]
./a.out(main+0x60) [0x55c54521e581]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fa18ef040b3]
./a.out(_start+0x2e) [0x55c54521e1ce]

ERROR tests/test_system_usage.c, test_error, 29
Another terrible error has occured!

./a.out(test_error+0xdf) [0x55c54521e4b0]
./a.out(main+0x60) [0x55c54521e581]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fa18ef040b3]
./a.out(_start+0x2e) [0x55c54521e1ce]

ERROR tests/test_system_usage.c, test_error, 30
Yet another terrible error has occured!

./a.out(test_error+0xdf) [0x55c54521e4b0]
./a.out(main+0x60) [0x55c54521e581]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fa18ef040b3]
./a.out(_start+0x2e) [0x55c54521e1ce]

ERROR tests/test_system_usage.c, test_error, 31
Please throw your computer in the bathtub!

./a.out(test_error+0xdf) [0x55c54521e4b0]
./a.out(main+0x60) [0x55c54521e581]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fa18ef040b3]
./a.out(_start+0x2e) [0x55c54521e1ce]
```