### PR TITLE
free memory in graph_add_edge & graph_add_node when adding fails

### DIFF
--- a/graph/src/graph_add_edge.c
+++ b/graph/src/graph_add_edge.c
@@ -25,6 +25,7 @@ ssize_t	graph_add_edge(
 	if (!u || !v)
 	{
 		print("Trying to connect an edge with a non-existing node!\n");
+		free(e);
 		return (-1);
 	}
 	e->u = u;

--- a/graph/src/graph_add_node.c
+++ b/graph/src/graph_add_node.c
@@ -26,5 +26,13 @@ ssize_t	graph_add_node(t_graph *g, const char *key, void *attr)
 	n->in = parr_new(1);
 	n->out = parr_new(1);
 	n->attr = attr;
-	return (map_add(g, n, n->key));
+	if (!map_add(g, n, n->key))
+	{
+		parr_free(&n->in);
+		parr_free(&n->out);
+		free(n);
+		return (CR_FAIL);
+	}
+	else
+		return (CR_SUCCESS);
 }


### PR DESCRIPTION
Adding an edge may fail because nodes corresponding to the keys are not found. On the other hand, adding a node fails if a node already exists with the same key. 